### PR TITLE
httpx initial client headers are respected and merged

### DIFF
--- a/src/requestmodel/adapters/httpx.py
+++ b/src/requestmodel/adapters/httpx.py
@@ -15,7 +15,11 @@ class HTTPXAdapter(BaseAdapter):
     ) -> Request:
         request_args = model.request_args_for_values()
 
-        headers = request_args[params.Header]
+        headers = client.headers
+
+        if request_args[params.Header]:
+            headers.update(request_args[params.Header])
+
         body = request_args[params.Body]
 
         is_json_request = "json" in headers.get("content-type", "")

--- a/tests/test_httpx_adapter.py
+++ b/tests/test_httpx_adapter.py
@@ -1,0 +1,11 @@
+from httpx import Client
+
+from tests.locatieserver.requests import LookupRequest
+
+
+def test_preserve_header() -> None:
+    client = Client(headers={"X-Test": "test"})
+
+    request = LookupRequest(id="test").as_request(client)
+
+    assert request.headers["X-Test"] == "test"


### PR DESCRIPTION
When an client is initiated with the headers are overwritten when a request model contains headers 