### PR TITLE
Add coverage TypeAdapter in asend

### DIFF
--- a/src/requestmodel/adapters/requests.py
+++ b/src/requestmodel/adapters/requests.py
@@ -50,4 +50,4 @@ class RequestsRequestModel(BaseRequestModel[ResponseType]):
         r = self.as_request()
         self.response = client.send(r.prepare())
         self.handle_error(self.response)
-        return self.response_model.model_validate(self.response.json())
+        return self.adapt_type(self.response)

--- a/src/requestmodel/model.py
+++ b/src/requestmodel/model.py
@@ -29,7 +29,7 @@ from .utils import get_annotated_type
 from .utils import unify_body
 
 
-class JSONResponse(Protocol):
+class JSONResponse(Protocol):  # pragma: no cover
     def json(self) -> Any: ...  # noqa: E704
 
 

--- a/src/requestmodel/typing.py
+++ b/src/requestmodel/typing.py
@@ -1,11 +1,17 @@
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Type
 from typing import TypeVar
+from typing import Union
 
 from pydantic import BaseModel
+from pydantic import TypeAdapter
 from pydantic.fields import FieldInfo
 
 
-ResponseType = TypeVar("ResponseType", bound=BaseModel)
+ResponseType = TypeVar(
+    "ResponseType",
+    bound=Union[BaseModel, TypeAdapter[List[BaseModel]], List[BaseModel]],
+)
 RequestArgs = Dict[Type[FieldInfo], Dict[str, Any]]

--- a/tests/test_request_model.py
+++ b/tests/test_request_model.py
@@ -220,8 +220,8 @@ def test_type_adapter() -> None:
 async def test_type_adapter_async() -> None:
     request = TypeAdapterRequest()
 
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(app=app, base_url="http://test", timeout=30) as aclient:
 
-        response = await request.asend(client)
+        response = await request.asend(aclient)
 
     assert response == [NameModel(name="test")]

--- a/tests/test_request_model.py
+++ b/tests/test_request_model.py
@@ -8,6 +8,7 @@ from typing import Type
 import pytest
 from fastapi._compat import field_annotation_is_scalar
 from fastapi._compat import field_annotation_is_sequence
+from httpx import AsyncClient
 from pydantic import BaseModel
 from pydantic import ValidationError
 from typeguard import suppress_type_checks
@@ -19,6 +20,7 @@ from typing_extensions import get_type_hints
 from requestmodel import RequestModel
 from requestmodel import params
 from requestmodel.utils import get_annotated_type
+from tests.fastapi_server import app
 from tests.fastapi_server import client
 from tests.fastapi_server.schema import NameModel
 from tests.fastapi_server.schema import NameModelList
@@ -209,5 +211,17 @@ class TypeAdapterRequest(RequestModel[List[NameModel]]):  # type: ignore[type-va
 def test_type_adapter() -> None:
     request = TypeAdapterRequest()
     response = request.send(client)
+
+    assert response == [NameModel(name="test")]
+
+
+@suppress_type_checks
+@pytest.mark.asyncio
+async def test_type_adapter_async() -> None:
+    request = TypeAdapterRequest()
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+
+        response = await request.asend(client)
 
     assert response == [NameModel(name="test")]


### PR DESCRIPTION
TypeAdapter support for async requests is added in v0.6.1 but it is lacking a test-case. 