### PR TITLE
Remove scalar type validation

### DIFF
--- a/src/requestmodel/utils.py
+++ b/src/requestmodel/utils.py
@@ -42,21 +42,6 @@ def get_annotated_type(
     else:
         annotated_property = params.Query()
 
-    scalar_types = (params.Query, params.Path, params.Header, params.Cookie)
-
-    if isinstance(annotated_property, scalar_types) and is_complex:
-        # query params do accept lists
-        if not (isinstance(annotated_property, params.Query) and is_sequence):
-            annotated_name = annotated_property.__class__.__name__
-
-            # in 3.8 & 3.9 Dict does not have a __name__
-            if not hasattr(origin, "__name__"):
-                origin = get_origin(origin)
-            raise ValueError(
-                f"`{variable_key}` annotated as {annotated_name} "
-                f"can only be a scalar, not a `{origin.__name__}`"
-            )
-
     return annotated_property
 
 

--- a/tests/test_request_model.py
+++ b/tests/test_request_model.py
@@ -101,30 +101,12 @@ def test_get_annotated_type() -> None:
     assert isinstance(get_annotated_type("d", hints["d"]), params.Body)
     assert isinstance(get_annotated_type("e", hints["e"]), params.Body)
 
-    with pytest.raises(ValueError, match="can only be a scalar"):
-        assert isinstance(get_annotated_type("f", hints["f"]), params.Path)
-
-    with pytest.raises(ValueError, match="can only be a scalar"):
-        assert isinstance(get_annotated_type("g", hints["g"]), params.Query)
-
 
 def test_annotated_type() -> None:
     assert isinstance(
         get_annotated_type("w", Annotated[List[str], params.Query()]), params.Query
     )
     assert isinstance(get_annotated_type("w", List[str]), params.Query)
-
-    with pytest.raises(
-        ValueError,
-        match="`x` annotated as Query can only be a scalar, not a `SimpleResponse`",
-    ):
-        get_annotated_type("x", Annotated[SimpleResponse, params.Query()])
-
-    with pytest.raises(
-        ValueError,
-        match="`y` annotated as Query can only be a scalar, not a `(.)ict`",
-    ):
-        get_annotated_type("y", Annotated[Dict[str, str], params.Query()])
 
 
 def test_field_annotation_is_sequence() -> None:


### PR DESCRIPTION
The applied validation is to simplistic since dictionaries can be serialized into query parameters. Validation should be validated through the transport client and not on our end. 